### PR TITLE
WOL Power

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,18 @@ This has been designed with the goal of running the webserver on a Raspberry Pi 
 ## Setup
 
 * A simple `go run ledAPI.go` is sufficient at the current time to run this locally or on a Pi
-> In future this will be packaged into a binary that only need be run
+
+### Binary Run
+
+* If you need to rebuild the binary `go build` will build and package the binary under the name `ledAPI`
+* This can then be run with `./ledAPI` - or using `nohup ./ledAPI &` if you want to run it in the background on a Pi
+    * To find the PID you can run `ps -ef | grep led` and then `kill -9 <pid>` to stop the process
 
 ## Endpoints
 
 * `<staticIP>:10000/colour/{colour}` will be used to set all LEDs to a chosen colour - this will initially be from a preset list
 * `<staticIP>:10000/preset/{preset}` will be used to chose a preset for the strip i.e. transition through all colours
+* `<staticIP>:10000/pcon` will turn on a PC that has the MAC address listed in to the code providing it's on the same network
 
 ## Useful links
 * https://www.unix.com/shell-programming-and-scripting/195303-how-stop-nohup-working-background.html

--- a/README.md
+++ b/README.md
@@ -11,3 +11,8 @@ This has been designed with the goal of running the webserver on a Raspberry Pi 
 
 * `<staticIP>:10000/colour/{colour}` will be used to set all LEDs to a chosen colour - this will initially be from a preset list
 * `<staticIP>:10000/preset/{preset}` will be used to chose a preset for the strip i.e. transition through all colours
+
+## Useful links
+* https://www.unix.com/shell-programming-and-scripting/195303-how-stop-nohup-working-background.html
+* https://sabhiram.com/development/2015/02/16/sending_wol_packets_with_golang.html
+* https://medium.com/the-andela-way/build-a-restful-json-api-with-golang-85a83420c9da

--- a/main.go
+++ b/main.go
@@ -22,5 +22,6 @@ func main() {
 	router.HandleFunc("/colour/{colour}", server.GetColour).Methods("GET")
 	router.HandleFunc("/preset/{preset}", server.SetPreset).Methods("GET")
 	router.HandleFunc("/pin/{set}", server.SetPin).Methods("GET")
+	router.HandleFunc("/pcon", server.PowerOn).Methods("GET")
 	log.Fatal(http.ListenAndServe(":10000", router))
 }

--- a/webserver/webserver.go
+++ b/webserver/webserver.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gorilla/mux"
 
 	led "ledAPI/ledcontrols"
+	wol "ledAPI/wolPower"
 )
 
 func HomeLink(w http.ResponseWriter, r *http.Request) {
@@ -36,4 +37,10 @@ func SetPin(w http.ResponseWriter, r *http.Request){
 	led.SetPinOut(pinSet)
 
 	fmt.Fprintf(w, "Pin set to: "+pinSet)
+func PowerOn(w http.ResponseWriter, r *http.Request){
+	fmt.Fprintf(w, "PC on command sent")
+	err := wol.SendMagicPacket("B4-2E-99-9A-70-A9")
+	if err != nil {
+		fmt.Printf("ERROR YO\n")
+	}
 }

--- a/wolPower/poweron.go
+++ b/wolPower/poweron.go
@@ -1,0 +1,41 @@
+package wolPower
+
+import (
+	"errors"
+	"net"
+)
+
+// This function accepts a MAC Address string, and returns a pointer to
+// a MagicPacket object. A Magic Packet is a broadcast frame which
+// contains 6 bytes of 0xFF followed by 16 repetitions of a given mac address.
+func NewMagicPacket(mac string) (*MagicPacket, error) {
+    var packet MagicPacket
+    var macAddr MacAddress
+
+    // We only support 6 byte MAC addresses
+    if !re_MAC.MatchString(mac) {
+        return nil, errors.New("MAC address " + mac + " is not valid.")
+    }
+
+    hwAddr, err := net.ParseMAC(mac)
+    if err != nil {
+        return nil, err
+    }
+
+    // Copy bytes from the returned HardwareAddr -> a fixed size MACAddress
+    for idx := range macAddr {
+        macAddr[idx] = hwAddr[idx]
+    }
+
+    // Setup the header which is 6 repetitions of 0xFF
+    for idx := range packet.header {
+        packet.header[idx] = 0xFF
+    }
+
+    // Setup the payload which is 16 repetitions of the MAC addr
+    for idx := range packet.payload {
+        packet.payload[idx] = macAddr
+    }
+
+    return &packet, nil
+}

--- a/wolPower/sendpacket.go
+++ b/wolPower/sendpacket.go
@@ -1,0 +1,47 @@
+package wolPower
+
+import (
+	"net"
+	"bytes"
+	"encoding/binary"
+	"fmt"
+)
+
+// This function accepts a MAC address string, and s
+// Function to send a magic packet to a given mac address
+func SendMagicPacket(macAddr string) error {
+    magicPacket, err := NewMagicPacket(macAddr)
+    if err != nil {
+        return err
+    }
+
+    // Fill our byte buffer with the bytes in our MagicPacket
+    var buf bytes.Buffer
+    binary.Write(&buf, binary.BigEndian, magicPacket)
+
+    // Get a UDPAddr to send the broadcast to
+    udpAddr, err := net.ResolveUDPAddr("udp", "255.255.255.255:9")
+    if err != nil {
+        fmt.Printf("Unable to get a UDP address for %s\n", "255.255.255.255:9")
+        return err
+    }
+
+    // Open a UDP connection, and defer its cleanup
+    connection, err := net.DialUDP("udp", nil, udpAddr)
+    if err != nil {
+        fmt.Printf("Unable to dial UDP address for %s\n", "255.255.255.255:9")
+        return err
+    }
+    defer connection.Close()
+
+    // Write the bytes of the MagicPacket to the connection
+    bytesWritten, err := connection.Write(buf.Bytes())
+    if err != nil {
+        fmt.Printf("Unable to write packet to connection\n")
+        return err
+    } else if bytesWritten != 102 {
+        fmt.Printf("Warning: %d bytes written, %d expected!\n", bytesWritten, 102)
+    }
+
+    return nil
+}

--- a/wolPower/structures.go
+++ b/wolPower/structures.go
@@ -1,0 +1,19 @@
+package wolPower
+
+import "regexp"
+
+// A MacAddress is 6 bytes in a row
+type MacAddress [6]byte
+
+// A MagicPacket is constituted of 6 bytes of 0xFF followed by
+// 16 groups of the destination MAC address.
+type MagicPacket struct {
+    header  [6]byte
+    payload [16]MacAddress
+}
+
+// Define globals for MacAddress parsing
+var (
+    delims = ":-"
+    re_MAC = regexp.MustCompile(`^([0-9a-fA-F]{2}[`+delims+`]){5}([0-9a-fA-F]{2})$`)
+)


### PR DESCRIPTION
This PR adds the ability to wake-on-lan (WOL) based on the MAC address of a PC. 
> *Note that WOL must be enabled on the PC for this to work*

To use this functionality run the binary and then go to the address `<IP>:10000/pcon` which will send the required 'magic packet' to power on the PC.
